### PR TITLE
fix(rust): resolve aws-lc-sys versions, add deduping in TestVectors

### DIFF
--- a/.github/workflows/rust_duplicate_deps.yml
+++ b/.github/workflows/rust_duplicate_deps.yml
@@ -47,15 +47,16 @@ jobs:
       # running codegen.
       - name: Stub generated targets
         shell: bash
-        working-directory: ./AwsEncryptionSDK/runtimes/rust
         run: |
-          mkdir -p src examples
-          [ -f src/lib.rs ] || : > src/lib.rs
-          [ -f examples/main.rs ] || echo 'fn main() {}' > examples/main.rs
+          for dir in AwsEncryptionSDK/runtimes/rust TestVectors/runtimes/rust; do
+            mkdir -p "$dir/src" "$dir/examples"
+            [ -f "$dir/src/lib.rs" ] || : > "$dir/src/lib.rs"
+            [ -f "$dir/src/main.rs" ] || echo 'fn main() {}' > "$dir/src/main.rs"
+            [ -f "$dir/examples/main.rs" ] || echo 'fn main() {}' > "$dir/examples/main.rs"
+          done
 
       - name: Check for duplicate aws-lc-sys / aws-lc-fips-sys
         shell: bash
-        working-directory: ./AwsEncryptionSDK/runtimes/rust
         run: |
           set -euo pipefail
           status=0
@@ -65,8 +66,11 @@ jobs:
           # package followed by the reverse-dependency tree, so it shows exactly
           # which package pulls in each version (e.g. the direct dep vs aws-lc-rs).
           check_profile() {
-            label="$1"
-            args="$2"
+            dir="$1"
+            label="$2"
+            args="$3"
+
+            pushd "$dir" >/dev/null
 
             # Liveness guard: a "no duplicates" result is only trustworthy if the
             # tree actually resolved. This check intentionally ignores cargo
@@ -75,8 +79,9 @@ jobs:
             # aws-lc-rs is a non-optional dependency, so it MUST appear; if it
             # does not, fail loudly instead of reporting a false "all clear".
             if ! cargo tree $args 2>/dev/null | grep -q 'aws-lc-rs v'; then
-              echo "::error::Duplicate check could not resolve the dependency tree ($label build) -- failing instead of passing silently. Run 'cargo tree $args' locally to debug."
+              echo "::error::Duplicate check could not resolve the dependency tree ($dir, $label build) -- failing instead of passing silently. Run 'cargo tree $args' in $dir locally to debug."
               status=1
+              popd >/dev/null
               return
             fi
 
@@ -84,9 +89,9 @@ jobs:
             awslc=$(printf '%s\n' "$dup" | awk 'BEGIN{RS="";ORS="\n\n"} /^aws-lc-(sys|fips-sys) v/' || true)
             if [ -n "$(printf '%s' "$awslc" | tr -d '[:space:]')" ]; then
               status=1
-              echo "::error::Duplicate aws-lc native crate detected ($label build). See log for how to fix."
+              echo "::error::Duplicate aws-lc native crate detected ($dir, $label build). See log for how to fix."
               echo "------------------------------------------------------------------------"
-              echo "Duplicate aws-lc native crate(s) in the $label dependency tree."
+              echo "Duplicate aws-lc native crate(s) in the $label dependency tree of $dir."
               echo "Each version below compiles a separate copy of AWS-LC. The tree shows"
               echo "which package pulls in each version:"
               echo ""
@@ -104,8 +109,14 @@ jobs:
               echo "to (shown above), then confirm locally with:  cargo tree -d"
               echo "------------------------------------------------------------------------"
             fi
+
+            popd >/dev/null
           }
 
-          check_profile "default" ""
-          check_profile "fips" "--no-default-features --features fips"
+          # Every Rust runtime crate that pins aws-lc-*-sys directly must be
+          # checked -- the ESDK library and the TestVectors binary each FIPS-build.
+          for dir in AwsEncryptionSDK/runtimes/rust TestVectors/runtimes/rust; do
+            check_profile "$dir" "default" ""
+            check_profile "$dir" "fips" "--no-default-features --features fips"
+          done
           exit $status

--- a/.github/workflows/rust_duplicate_deps.yml
+++ b/.github/workflows/rust_duplicate_deps.yml
@@ -95,16 +95,20 @@ jobs:
               # The version aws-lc-rs actually pulls in -- this is the one to pin to.
               want=$(cargo tree $args -p aws-lc-rs 2>/dev/null \
                 | grep -oE "$crate v[0-9][0-9.]*" | head -1 | grep -oE '[0-9][0-9.]*')
-              # What Cargo.toml declares directly today, with its line number.
+              # The aws-lc-rs version doing the resolving.
+              rs_ver=$(cargo tree $args -p aws-lc-rs 2>/dev/null \
+                | grep -oE 'aws-lc-rs v[0-9][0-9.]*' | head -1 | grep -oE '[0-9][0-9.]*')
+              # Repo-relative path to the offending Cargo.toml, and the line to change.
+              cargo_path="$dir/Cargo.toml"
               cargo_line=$(grep -nE "^$crate[[:space:]]*=" Cargo.toml | head -1)
               cur=$(printf '%s' "$cargo_line" | grep -oE '[0-9][0-9.]+' | head -1)
               lineno=$(printf '%s' "$cargo_line" | cut -d: -f1)
 
-              echo "::error::$crate is duplicated in $dir ($label build). Fix: pin it to $want in Cargo.toml."
-              echo "$dir/Cargo.toml line $lineno:"
-              echo "    - $crate = \"$cur\""
-              echo "    + $crate = \"$want\""
-              echo "(aws-lc-rs resolves $crate to v$want; matching it collapses the two AWS-LC builds into one.)"
+              echo "::error::$crate versions aren't consistent. Fix: pin it to $want in $cargo_path."
+              echo "In $cargo_path line $lineno, change"
+              echo "- $crate = \"$cur\""
+              echo "+ $crate = \"$want\""
+              echo "(aws-lc-rs v$rs_ver resolves $crate to v$want; matching it avoids inconsistencies.)"
             fi
 
             popd >/dev/null

--- a/.github/workflows/rust_duplicate_deps.yml
+++ b/.github/workflows/rust_duplicate_deps.yml
@@ -79,7 +79,7 @@ jobs:
             # aws-lc-rs is a non-optional dependency, so it MUST appear; if it
             # does not, fail loudly instead of reporting a false "all clear".
             if ! cargo tree $args 2>/dev/null | grep -q 'aws-lc-rs v'; then
-              echo "::error::Duplicate check could not resolve the dependency tree ($dir, $label build) -- failing instead of passing silently. Run 'cargo tree $args' in $dir locally to debug."
+              echo "::error::Duplicate check could not resolve the dependency tree ($dir, $label build). Run 'cargo tree $args' in $dir locally to debug."
               status=1
               popd >/dev/null
               return
@@ -89,25 +89,22 @@ jobs:
             awslc=$(printf '%s\n' "$dup" | awk 'BEGIN{RS="";ORS="\n\n"} /^aws-lc-(sys|fips-sys) v/' || true)
             if [ -n "$(printf '%s' "$awslc" | tr -d '[:space:]')" ]; then
               status=1
-              echo "::error::Duplicate aws-lc native crate detected ($dir, $label build). See log for how to fix."
-              echo "------------------------------------------------------------------------"
-              echo "Duplicate aws-lc native crate(s) in the $label dependency tree of $dir."
-              echo "Each version below compiles a separate copy of AWS-LC. The tree shows"
-              echo "which package pulls in each version:"
-              echo ""
-              printf '%s\n' "$awslc" | sed 's/^/    /'
-              echo "Declared directly in this crate's Cargo.toml:"
-              grep -nE '^aws-lc-(sys|fips-sys)[[:space:]]' Cargo.toml | sed 's/^/    /' || true
-              echo ""
-              echo "Why this matters: a different DIRECT -sys version forces a second copy"
-              echo "of AWS-LC to compile (~2x native C build time + larger binary), and the"
-              echo "SDK's raw FFI (aws_lc_sys_impl::*) then uses the version YOU declared"
-              echo "while aws-lc-rs uses the one it pulls in -- so the raw path can stay on a"
-              echo "stale/vulnerable AWS-LC independently of aws-lc-rs."
-              echo ""
-              echo "How to fix: set the direct version to the SAME version aws-lc-rs resolves"
-              echo "to (shown above), then confirm locally with:  cargo tree -d"
-              echo "------------------------------------------------------------------------"
+
+              # Which -sys crate is duplicated (aws-lc-sys or aws-lc-fips-sys).
+              crate=$(printf '%s\n' "$awslc" | grep -oE 'aws-lc-(sys|fips-sys)' | head -1)
+              # The version aws-lc-rs actually pulls in -- this is the one to pin to.
+              want=$(cargo tree $args -p aws-lc-rs 2>/dev/null \
+                | grep -oE "$crate v[0-9][0-9.]*" | head -1 | grep -oE '[0-9][0-9.]*')
+              # What Cargo.toml declares directly today, with its line number.
+              cargo_line=$(grep -nE "^$crate[[:space:]]*=" Cargo.toml | head -1)
+              cur=$(printf '%s' "$cargo_line" | grep -oE '[0-9][0-9.]+' | head -1)
+              lineno=$(printf '%s' "$cargo_line" | cut -d: -f1)
+
+              echo "::error::$crate is duplicated in $dir ($label build). Fix: pin it to $want in Cargo.toml."
+              echo "$dir/Cargo.toml line $lineno:"
+              echo "    - $crate = \"$cur\""
+              echo "    + $crate = \"$want\""
+              echo "(aws-lc-rs resolves $crate to v$want; matching it collapses the two AWS-LC builds into one.)"
             fi
 
             popd >/dev/null

--- a/AwsEncryptionSDK/runtimes/rust/Cargo.toml
+++ b/AwsEncryptionSDK/runtimes/rust/Cargo.toml
@@ -16,9 +16,9 @@ readme = "README.md"
 
 [dependencies]
 aws-config = "1.8.12"
-aws-lc-rs = {version = "1.17.0"}
-aws-lc-sys = { version = "0.42", optional = true }
-aws-lc-fips-sys = { version = "0.13.1", optional = true }
+aws-lc-rs = {version = "1.18.0"}
+aws-lc-sys = { version = "0.44", optional = true }
+aws-lc-fips-sys = { version = "0.14.1", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"
 aws-smithy-runtime-api = {version = "1.10.0", features = ["client"] }

--- a/TestVectors/runtimes/rust/Cargo.toml
+++ b/TestVectors/runtimes/rust/Cargo.toml
@@ -11,9 +11,9 @@ readme = "README.md"
 
 [dependencies]
 aws-config = "1.8.12"
-aws-lc-rs = {version = "1.15.4"}
-aws-lc-sys = { version = "0.39", optional = true }
-aws-lc-fips-sys = { version = "0.13", optional = true }
+aws-lc-rs = {version = "1.18.0"}
+aws-lc-sys = { version = "0.44", optional = true }
+aws-lc-fips-sys = { version = "0.14.1", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"
 aws-smithy-runtime-api = {version = "1.10.0", features = ["client"] }


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

* Resolve aws-lc-sys versions (this fixes CI)
* Add the aws-lc dedupe check to TestVectors
* Replace verbose failure message slop with something useful.
ex. from actual DBESDK message log

```
Error: aws-lc-sys versions aren't consistent. Fix: pin it to 0.44.0 in DynamoDbEncryption/runtimes/rust/Cargo.toml.
In DynamoDbEncryption/runtimes/rust/Cargo.toml line 20, change
- aws-lc-sys = "0.43"
+ aws-lc-sys = "0.44.0"
(aws-lc-rs v1.18.0 resolves aws-lc-sys to v0.44.0; matching it avoids inconsistencies.)
```

_Squash/merge commit message, if applicable:_

fix(rust): resolve aws-lc-sys versions, add deduping in TestVectors

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
