### PR TITLE
fix(ci): show real current version in duplicate-deps error message

### DIFF
--- a/.github/workflows/rust_duplicate_deps.yml
+++ b/.github/workflows/rust_duplicate_deps.yml
@@ -101,8 +101,10 @@ jobs:
               # Repo-relative path to the offending Cargo.toml, and the line to change.
               cargo_path="$dir/Cargo.toml"
               cargo_line=$(grep -nE "^$crate[[:space:]]*=" Cargo.toml | head -1)
-              cur=$(printf '%s' "$cargo_line" | grep -oE '[0-9][0-9.]+' | head -1)
               lineno=$(printf '%s' "$cargo_line" | cut -d: -f1)
+              # Strip grep -n's "N:" line-number prefix before reading the
+              # version, otherwise the line number is misread as the version.
+              cur=$(printf '%s' "${cargo_line#*:}" | grep -oE '[0-9][0-9.]+' | head -1)
 
               echo "::error::$crate versions aren't consistent. Fix: pin it to $want in $cargo_path."
               echo "In $cargo_path line $lineno, change"

--- a/AwsEncryptionSDK/runtimes/rust/Cargo.toml
+++ b/AwsEncryptionSDK/runtimes/rust/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 [dependencies]
 aws-config = "1.8.12"
 aws-lc-rs = {version = "1.18.0"}
-aws-lc-sys = { version = "0.44", optional = true }
+aws-lc-sys = { version = "0.45.0", optional = true }
 aws-lc-fips-sys = { version = "0.14.1", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"

--- a/TestVectors/runtimes/rust/Cargo.toml
+++ b/TestVectors/runtimes/rust/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 aws-config = "1.8.12"
 aws-lc-rs = {version = "1.18.0"}
-aws-lc-sys = { version = "0.44", optional = true }
+aws-lc-sys = { version = "0.45.0", optional = true }
 aws-lc-fips-sys = { version = "0.14.1", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:

Fix the error message displayed by `rust_duplicate_deps.yml`

### Squash/merge commit message, if applicable:

```
fix(ci): show real current version in duplicate-deps error message
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
